### PR TITLE
Fix quotation marks in metadata-and-state.md

### DIFF
--- a/docs/00-scd/07-hello-world-metadata/metadata-and-state.md
+++ b/docs/00-scd/07-hello-world-metadata/metadata-and-state.md
@@ -103,7 +103,7 @@ extern "C" fn state() {
     let greeting = unsafe {
         GREETING
             .as_ref()
-            .expect(“The contract is not initialized”)
+            .expect("The contract is not initialized")
     };
     msg::reply(greeting, 0).expect("Failed to share state");
 }


### PR DESCRIPTION
Changed sections:

-docs/00-scd/07-hello-world-metadata/metadata-and-state.md
-

