### PR TITLE
Fix code block display in testing-with-gtest.md

### DIFF
--- a/docs/00-scd/04-hello-world-testing/testing-with-gtest.md
+++ b/docs/00-scd/04-hello-world-testing/testing-with-gtest.md
@@ -139,6 +139,7 @@ To do this, we can use the `assert!(res.log().is_empty())` command.
     ```rust
     assert!(!res.main_failed());
     ```
+
 After confirming the successful initialization message, we process the next messages through the `handle` function. To test this, we can send the next message using the `program.send(2, String::from("Hello"))` command.
 
 ```rust


### PR DESCRIPTION
fix incorrect code block rendering by adding a extra white space

![image](https://github.com/gear-foundation/academy/assets/54848194/471fc416-9536-4f5d-b6d4-de968e7c1e0a)